### PR TITLE
Upgrade to MAFOT 5.7

### DIFF
--- a/source/MHDClass.py
+++ b/source/MHDClass.py
@@ -706,7 +706,7 @@ class MHD:
         return
 
     def getMultipleFieldPaths(self, dphi, gridfile, controlfilePath,
-                                controlfile, paraview_mask=False):
+                                controlfile, bbox=True, paraview_mask=False):
 
         args = []
         #args 0 is MAFOT structure binary call
@@ -718,7 +718,11 @@ class MHD:
         #args 3,4 are the points that we launch traces from
         args.append('-P')
         args.append(gridfile)
-        #args 5 is the MAFOT control file
+        #args 5 use simple boundary instead of g-file wall as limiter
+	    #This must be used with MAFOT version 5.7 or newer for the Shadow Mask calculation
+        if bbox is True:
+            args.append('-b')
+	    #args 6 is the MAFOT control file
         args.append(controlfile)
         #Copy the current environment (important when in appImage mode)
         current_env = os.environ.copy()


### PR DESCRIPTION
The function getMultipleFiledPaths in MHDClass.py has been modified to use the MAFOT version 5.7. 

Main changes:
   - added "bbox=True" option;
   - added "-b" option as args 5 in the call to MAFOT heatstructure that now is mandatory for the calculation of the Shadow 
     Mask
   