### PR TITLE
Fix M3D-C1 (fusion-io) build failure in Docker CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,8 +21,10 @@
 # times out on ubuntu-latest, increase timeout-minutes (max 360 on hosted runners)
 # or use a larger/self-hosted runner.
 
-name: Publish HEAT Docker image
+name: Build and publish HEAT Docker image
 
+# Runs only when you click "Run workflow" on the Actions tab. Not triggered by
+# push, pull_request, merge to main, or schedule.
 on:
   workflow_dispatch:
     inputs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,6 +86,8 @@ WORKDIR /root
 RUN git clone https://github.com/nferraro/fusion-io.git /root/source/M3DC1/fusion-io
 COPY docker/buildM3DC1 /root/source/M3DC1/fusion-io/buildM3DC1
 COPY docker/make.inc.ubuntu_x86 /root/source/M3DC1/fusion-io/install/make.inc.ubuntu_x86
+# Upstream util/makefile forces Intel mpiicpc / -qopenmp; Ubuntu image uses GCC + Open MPI only.
+COPY docker/fusion-io-util-makefile /root/source/M3DC1/fusion-io/util/makefile
 RUN mkdir -p /root/source/M3DC1/build && /root/source/M3DC1/fusion-io/buildM3DC1
 
 #clone and build MAFOT

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,6 +87,7 @@ RUN git clone https://github.com/nferraro/fusion-io.git /root/source/M3DC1/fusio
 COPY docker/buildM3DC1 /root/source/M3DC1/fusion-io/buildM3DC1
 COPY docker/make.inc.ubuntu_x86 /root/source/M3DC1/fusion-io/install/make.inc.ubuntu_x86
 # Upstream util/makefile forces Intel mpiicpc / -qopenmp; Ubuntu image uses GCC + Open MPI only.
+# we create a custom makefile that uses GCC + Open MPI.
 COPY docker/fusion-io-util-makefile /root/source/M3DC1/fusion-io/util/makefile
 # write_neo_input.cpp calls MPI but omits <mpi.h>; mpiicpc often still compiles, Open MPI mpic++ does not.
 #this needs to be fixed in fusion-io upstream, but for now we can add the include here.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,6 +88,10 @@ COPY docker/buildM3DC1 /root/source/M3DC1/fusion-io/buildM3DC1
 COPY docker/make.inc.ubuntu_x86 /root/source/M3DC1/fusion-io/install/make.inc.ubuntu_x86
 # Upstream util/makefile forces Intel mpiicpc / -qopenmp; Ubuntu image uses GCC + Open MPI only.
 COPY docker/fusion-io-util-makefile /root/source/M3DC1/fusion-io/util/makefile
+# write_neo_input.cpp calls MPI but omits <mpi.h>; mpiicpc often still compiles, Open MPI mpic++ does not.
+#this needs to be fixed in fusion-io upstream, but for now we can add the include here.
+RUN grep -q '#include <mpi.h>' /root/source/M3DC1/fusion-io/util/write_neo_input.cpp || \
+    sed -i '/#include <netcdf.h>/a#include <mpi.h>' /root/source/M3DC1/fusion-io/util/write_neo_input.cpp
 RUN mkdir -p /root/source/M3DC1/build && /root/source/M3DC1/fusion-io/buildM3DC1
 
 #clone and build MAFOT

--- a/docker/fusion-io-util-makefile
+++ b/docker/fusion-io-util-makefile
@@ -1,0 +1,59 @@
+#######################################################
+# if we're not in the build directory, build it
+#######################################################
+ifeq (,$(filter _%,$(notdir $(CURDIR))))
+
+include $(FIO_ROOT)/install/common_header.mk
+
+#######################################################
+# if we are in the build directory, do normal build
+#######################################################
+else
+
+# set source directory
+VPATH=$(SRCDIR)
+
+# include platform-specific options
+include $(FIO_ROOT)/install/make.inc.$(FIO_ARCH)
+
+# --- OpenMP (GCC + OpenMPI; HEAT Docker / Ubuntu) ---
+# Upstream util/makefile uses Intel mpiicpc and -qopenmp; our image only has
+# mpicc/mpic++ (Open MPI). Keep behavior aligned with docker/make.inc.ubuntu_x86.
+CXX := mpic++
+
+CFLAGS   += -fopenmp -O3
+CXXFLAGS += -fopenmp -O3
+LDFLAGS  += -fopenmp
+F90FLAGS += -fopenmp
+# ---------------------------------
+
+CLIBS := -L$(FIO_ROOT)/fusion_io/_$(FIO_ARCH) -lfusionio \
+    -L$(FIO_ROOT)/m3dc1_lib/_$(FIO_ARCH) -lm3dc1 \
+    $(HDF5_LIBS) $(NETCDF_LIBS) $(LIBS)
+
+FLIBS := -L$(FIO_ROOT)/fusion_io/_$(FIO_ARCH) -lfusionio \
+    -L$(FIO_ROOT)/m3dc1_lib/_$(FIO_ARCH) -lm3dc1 \
+    $(HDF5_LIBS) -lhdf5_fortran $(LIBS)
+
+INCLUDE :=-I$(FIO_ROOT)/fusion_io -I$(FIO_ROOT)/fusion_io/_$(FIO_ARCH) \
+    -I$(FIO_ROOT)/m3dc1_lib -I$(FIO_ROOT)/m3dc1_lib/_$(FIO_ARCH) \
+    $(HDF5_INCLUDE) \
+    $(NETCDF_C_INCLUDE) \
+    $(INCLUDE)
+
+all : write_neo_input write_lp_input
+
+write_neo_input : write_neo_input.o
+	$(CXX) $(LDFLAGS) -o $@ $< $(CLIBS) $(CFLAGS)
+
+write_lp_input : write_lp_input.o
+	$(F90) $(LDFLAGS) -o $@ $< $(FLIBS) $(F90FLAGS)
+
+install : write_neo_input write_lp_input
+	mkdir -p $(FIO_INSTALL_DIR)/bin
+	cp write_neo_input $(FIO_INSTALL_DIR)/bin/
+	cp write_lp_input $(FIO_INSTALL_DIR)/bin/
+
+include $(FIO_ROOT)/install/common_footer.mk
+
+endif


### PR DESCRIPTION
## Fix M3D-C1 (fusion-io) build failure in Docker CI

### Summary
The container build currently fails in CI while building the M3D-C1 / fusion-io libraries:
```
process "/bin/bash -c mkdir -p /root/source/M3DC1/build && /root/source/M3DC1/fusion-io/buildM3DC1" did not complete successfully: exit code: 2
```

This PR fixes the two root causes. It contains **only** docker-build changes — no application/source code.

### Root causes & fixes
1. **Wrong compiler in fusion-io's `util/makefile`.** Upstream hard-codes Intel `mpiicpc` with `-qopenmp`, which don't exist in the GCC + Open MPI Ubuntu image. We now `COPY` a replacement `docker/fusion-io-util-makefile` that uses `mpic++` with `-fopenmp`, kept consistent with `docker/make.inc.ubuntu_x86`.
2. **Missing `<mpi.h>` include.** `write_neo_input.cpp` calls MPI but omits `#include <mpi.h>`. Intel's `mpiicpc` tolerated this; Open MPI's `mpic++` does not. The Dockerfile now injects the include via `sed` before building (idempotent — skipped if already present). *This should be fixed upstream in fusion-io; this is a stopgap.*

### Changes
- `docker/fusion-io-util-makefile` — new: GCC + Open MPI build of the fusion-io util targets.
- `docker/Dockerfile` — copy the custom fusion-io makefile and inject the `<mpi.h>` include before `buildM3DC1`.
- `.github/workflows/docker-publish.yml` — minor comment/name cleanup (the workflow itself already landed on main via #77).

### Testing
Container build completes past the `buildM3DC1` step that previously exited with code 2.

